### PR TITLE
Add backtics to an inline code

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,7 +50,7 @@ PLEASE review CONTRIBUTING.markdown prior to requesting a feature, filing a pull
 
 ### Data Attribute Settings
 
-In slick 1.5 you can now add settings using the data-slick attribute. You still need to call $(element).slick() to initialize slick on the element.
+In slick 1.5 you can now add settings using the data-slick attribute. You still need to call `$(element).slick()` to initialize slick on the element.
 
 Example:
 


### PR DESCRIPTION
Under the Data Attribute Settings, there's an inline code that's written in just plain text.

I added a backtick to make it written in the right format.

### Screenshots

Before change

![image](https://user-images.githubusercontent.com/87664239/179231053-f4124a3e-4065-46a7-8c7e-94c36187b1fc.png)

After change

![image](https://user-images.githubusercontent.com/87664239/179231259-a5fbbe7a-2004-48ba-aec0-fd626c72a7a4.png)

